### PR TITLE
feat: display properties in table layout

### DIFF
--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,30 +1,15 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import { BrowserRouter } from 'react-router-dom'
-// import { ThemeProvider } from '@mui/material/styles'
-// import { CssBaseline } from '@mui/material'
 import { muiTheme } from '../theme/mui-theme'
 import { useState } from 'react'
-import { ThemeProvider, createTheme } from '@mui/material/styles'
+import { ThemeProvider } from '@mui/material/styles'
 import CssBaseline from '@mui/material/CssBaseline'
 
 interface ProvidersProps {
   children: React.ReactNode
 }
 
-// Centralized theme object so it's created once and reused
-const theme = createTheme({
-  palette: {
-    primary: { main: '#1976d2' },
-    background: { default: '#f5f5f5' },
-  },
-  typography: {
-    // Include Japanese-friendly font stack for better rendering
-    fontFamily: ["'Roboto'", "'Noto Sans JP'", 'sans-serif'].join(','),
-  },
-  // Slightly rounder corners for a softer look
-  shape: { borderRadius: 8 },
-})
 
 export function Providers({ children }: ProvidersProps) {
   // Configure React Query client with sane defaults

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react-refresh/only-export-components */
 // Exporting component and style variants from the same file for convenience
 import * as React from "react"
 import { cva, type VariantProps } from "class-variance-authority"

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react-refresh/only-export-components */
 // This file exports both the Button component and its style variants
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"

--- a/src/pages/properties.tsx
+++ b/src/pages/properties.tsx
@@ -1,21 +1,28 @@
-import { 
-  Box, 
-  Typography, 
-  Button, 
-  TextField, 
-  Paper, 
+import {
+  Box,
+  Typography,
+  Button,
+  TextField,
+  Paper,
   InputAdornment,
-  Chip
+  Chip,
+  TableContainer,
+  Table,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableBody
 } from '@mui/material'
-import { Plus, Search, MapPin, Home, Users, Star, Calendar } from 'lucide-react'
+import { Plus, Search, MapPin } from 'lucide-react'
 import { mockProperties } from '@/data/properties'
 import { PageContainer } from '@/components/layout/page-container'
 
-// Properties page manages registered rental properties
+// 物件管理ページ: 登録済み物件を表形式で表示
 export function PropertiesPage() {
   return (
-    <Box>
-      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
+    <PageContainer>
+      {/* ページヘッダー */}
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
         <Box>
           <Typography variant="h4" component="h1" fontWeight={600} gutterBottom>
             物件管理
@@ -24,12 +31,11 @@ export function PropertiesPage() {
             登録物件の管理と新規物件の追加
           </Typography>
         </Box>
-        <Button variant="contained" startIcon={<Plus size={20} />}>
-          新規物件登録
-        </Button>
+        <Button variant="contained" startIcon={<Plus size={20} />}>新規物件登録</Button>
       </Box>
 
-      <Paper sx={{ p: 2, mb: 3 }}>
+      {/* 検索バーと地図表示ボタン */}
+      <Paper sx={{ p: 2 }}>
         <Box sx={{ display: 'flex', gap: 2, alignItems: 'center' }}>
           <TextField
             fullWidth
@@ -44,114 +50,66 @@ export function PropertiesPage() {
               ),
             }}
           />
-          <Button variant="outlined" startIcon={<MapPin size={16} />}>
-            地図表示
-          </Button>
+          <Button variant="outlined" startIcon={<MapPin size={16} />}>地図表示</Button>
         </Box>
       </Paper>
 
-      <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(300px, 1fr))', gap: 3 }}>
-        {mockProperties.map((property) => (
-          <Paper key={property.id} sx={{ overflow: 'hidden', height: '100%', display: 'flex', flexDirection: 'column' }}>
-              <Box sx={{ position: 'relative' }}>
-                <Box
-                  component="img"
-                  src={property.imageUrl}
-                  alt={property.name}
-                  sx={{
-                    width: '100%',
-                    height: 200,
-                    objectFit: 'cover',
-                  }}
-                />
-                <Chip
-                  label={property.type}
-                  size="small"
-                  sx={{
-                    position: 'absolute',
-                    top: 8,
-                    right: 8,
-                    backgroundColor: 'rgba(255, 255, 255, 0.9)',
-                  }}
-                />
-                <Box
-                  sx={{
-                    position: 'absolute',
-                    bottom: 8,
-                    left: 8,
-                    backgroundColor: 'rgba(0, 0, 0, 0.7)',
-                    color: 'white',
-                    px: 1.5,
-                    py: 0.5,
-                    borderRadius: 1,
-                  }}
-                >
-                  <Typography variant="body2" fontWeight={500}>
-                    ¥{property.pricePerNight.toLocaleString()}/泊
-                  </Typography>
-                </Box>
-              </Box>
-              
-              <Box sx={{ p: 2, flex: 1, display: 'flex', flexDirection: 'column' }}>
-                <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', mb: 1 }}>
-                  <Typography variant="h6" component="h3" sx={{ flex: 1, mr: 1 }}>
-                    {property.name}
-                  </Typography>
-                  <Box sx={{ display: 'flex', alignItems: 'center', color: 'text.secondary' }}>
-                    <Home size={16} style={{ marginRight: 4 }} />
-                    <Typography variant="body2">
-                      {property.rooms}部屋
-                    </Typography>
+      {/* 物件一覧テーブル */}
+      <TableContainer component={Paper} sx={{ overflowX: 'auto' }}>
+        <Table>
+          <TableHead>
+            <TableRow sx={{ backgroundColor: 'grey.100' }}>
+              <TableCell>物件</TableCell>
+              <TableCell>住所</TableCell>
+              <TableCell align="center">部屋数</TableCell>
+              <TableCell align="center">定員</TableCell>
+              <TableCell align="right">料金/泊</TableCell>
+              <TableCell align="right">更新日</TableCell>
+              <TableCell align="center">操作</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {mockProperties.map((property) => (
+              <TableRow key={property.id} hover>
+                <TableCell>
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+                    {/* 物件画像と名前 */}
+                    <Box
+                      component="img"
+                      src={property.imageUrl}
+                      alt={property.name}
+                      sx={{ width: 64, height: 64, borderRadius: 1, objectFit: 'cover', boxShadow: 1 }}
+                    />
+                    <Box>
+                      <Typography variant="subtitle1" fontWeight={600}>{property.name}</Typography>
+                      <Chip label={property.type} size="small" sx={{ mt: 0.5 }} />
+                    </Box>
                   </Box>
-                </Box>
-                
-                <Box sx={{ display: 'flex', alignItems: 'flex-start', mb: 2, color: 'text.secondary' }}>
-                  <MapPin size={16} style={{ marginRight: 8, marginTop: 2, flexShrink: 0 }} />
-                  <Typography variant="body2" sx={{ lineHeight: 1.4 }}>
-                    {property.address}
-                  </Typography>
-                </Box>
-                
-                <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
-                  <Box sx={{ display: 'flex', alignItems: 'center', color: 'text.secondary' }}>
-                    <Users size={16} style={{ marginRight: 4 }} />
-                    <Typography variant="body2">
-                      最大{property.maxGuests}名
-                    </Typography>
+                </TableCell>
+                <TableCell>
+                  <Typography variant="body2" sx={{ whiteSpace: 'pre-line' }}>{property.address}</Typography>
+                </TableCell>
+                <TableCell align="center">{property.rooms}</TableCell>
+                <TableCell align="center">{property.maxGuests}</TableCell>
+                <TableCell align="right">¥{property.pricePerNight.toLocaleString()}</TableCell>
+                <TableCell align="right">{new Date(property.updatedAt).toLocaleDateString('ja-JP')}</TableCell>
+                <TableCell align="center">
+                  <Box sx={{ display: 'flex', gap: 1, justifyContent: 'center' }}>
+                    <Button variant="outlined" size="small">詳細</Button>
+                    <Button variant="contained" size="small">編集</Button>
                   </Box>
-                  <Box sx={{ display: 'flex', alignItems: 'center', color: '#ffa726' }}>
-                    <Star size={14} style={{ marginRight: 4 }} />
-                    <Typography variant="body2" fontWeight={500}>
-                      4.8
-                    </Typography>
-                  </Box>
-                </Box>
-                
-                <Box sx={{ display: 'flex', alignItems: 'center', mb: 2, color: 'text.secondary' }}>
-                  <Calendar size={14} style={{ marginRight: 4 }} />
-                  <Typography variant="caption">
-                    更新: {new Date(property.updatedAt).toLocaleDateString('ja-JP')}
-                  </Typography>
-                </Box>
-                
-                <Box sx={{ display: 'flex', gap: 1, mt: 'auto' }}>
-                  <Button variant="outlined" size="small" sx={{ flex: 1 }}>
-                    詳細
-                  </Button>
-                  <Button variant="contained" size="small" sx={{ flex: 1 }}>
-                    編集
-                  </Button>
-                </Box>
-              </Box>
-            </Paper>
-        ))}
-      </Box>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
 
-      <Box sx={{ display: 'flex', justifyContent: 'center', mt: 4 }}>
-        <Button variant="outlined">
-          さらに表示
-        </Button>
+      {/* さらに表示ボタン */}
+      <Box sx={{ display: 'flex', justifyContent: 'center' }}>
+        <Button variant="outlined">さらに表示</Button>
       </Box>
-    </Box>
+    </PageContainer>
   )
 }
+


### PR DESCRIPTION
## Summary
- present property list in a sleek table with images and action buttons
- clean up unused theme code and eslint directives for smoother linting

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b1be89a9ac8324871c97b67c2151a9