### PR TITLE
feat: add contact page with enhanced UX

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,23 +1,24 @@
-import { Routes, Route, Navigate } from 'react-router-dom'
-import { Box } from '@mui/material'
-import { Sidebar } from '@/components/layout/sidebar'
-import { Header } from '@/components/layout/header'
-import { LoginPage } from '@/pages/login'
-import { PropertiesPage } from '@/pages/properties'
-import { JobsPage } from '@/pages/jobs'
-import { JobDetailPage } from '@/pages/job-detail'
-import { FavoriteStaffPage } from '@/pages/favorites'
-import { ProgressPage } from '@/pages/progress'
-import { ReviewsPage } from '@/pages/reviews'
-import { BillingPage } from '@/pages/billing'
-import { NotificationsPage } from '@/pages/notifications'
-import { SettingsPage } from '@/pages/settings'
+import { Routes, Route, Navigate } from 'react-router-dom';
+import { Box } from '@mui/material';
+import { Sidebar } from '@/components/layout/sidebar';
+import { Header } from '@/components/layout/header';
+import { LoginPage } from '@/pages/login';
+import { PropertiesPage } from '@/pages/properties';
+import { JobsPage } from '@/pages/jobs';
+import { JobDetailPage } from '@/pages/job-detail';
+import { FavoriteStaffPage } from '@/pages/favorites';
+import { ProgressPage } from '@/pages/progress';
+import { ReviewsPage } from '@/pages/reviews';
+import { BillingPage } from '@/pages/billing';
+import { NotificationsPage } from '@/pages/notifications';
+import { SettingsPage } from '@/pages/settings';
+import { ContactPage } from '@/pages/contact';
 
 function App() {
-  const isAuthenticated = localStorage.getItem('auth_token')
+  const isAuthenticated = localStorage.getItem('auth_token');
 
   if (!isAuthenticated) {
-    return <LoginPage />
+    return <LoginPage />;
   }
 
   return (
@@ -37,12 +38,13 @@ function App() {
             <Route path="/reviews" element={<ReviewsPage />} />
             <Route path="/billing" element={<BillingPage />} />
             <Route path="/notifications" element={<NotificationsPage />} />
+            <Route path="/contact" element={<ContactPage />} />
             <Route path="/settings" element={<SettingsPage />} />
           </Routes>
         </Box>
       </Box>
     </Box>
-  )
+  );
 }
 
-export default App
+export default App;

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -1,4 +1,4 @@
-import { Link, useLocation } from 'react-router-dom'
+import { Link, useLocation } from 'react-router-dom';
 import {
   Drawer,
   List,
@@ -7,8 +7,8 @@ import {
   ListItemIcon,
   ListItemText,
   Typography,
-  Box
-} from '@mui/material'
+  Box,
+} from '@mui/material';
 import {
   Home,
   Building2,
@@ -18,8 +18,9 @@ import {
   Star,
   CreditCard,
   Bell,
+  Mail,
   Settings,
-} from 'lucide-react'
+} from 'lucide-react';
 
 const navigation = [
   { name: 'ダッシュボード', href: '/', icon: Home },
@@ -30,12 +31,13 @@ const navigation = [
   { name: 'レビュー', href: '/reviews', icon: Star },
   { name: '請求・支払', href: '/billing', icon: CreditCard },
   { name: '通知', href: '/notifications', icon: Bell },
+  { name: 'お問い合わせ', href: '/contact', icon: Mail },
   { name: '設定', href: '/settings', icon: Settings },
-]
+];
 
 // Sidebar navigation using Material UI components for consistent styling
 export function Sidebar() {
-  const location = useLocation()
+  const location = useLocation();
 
   return (
     <Drawer
@@ -56,8 +58,8 @@ export function Sidebar() {
       </Box>
       <List sx={{ pt: 2 }}>
         {navigation.map((item) => {
-          const isActive = location.pathname === item.href
-          const IconComponent = item.icon
+          const isActive = location.pathname === item.href;
+          const IconComponent = item.icon;
           return (
             <ListItem key={item.name} disablePadding sx={{ px: 1 }}>
               <ListItemButton
@@ -82,9 +84,9 @@ export function Sidebar() {
                 <ListItemText primary={item.name} />
               </ListItemButton>
             </ListItem>
-          )
+          );
         })}
       </List>
     </Drawer>
-  )
+  );
 }

--- a/src/pages/contact.tsx
+++ b/src/pages/contact.tsx
@@ -1,0 +1,128 @@
+import { useState } from 'react';
+import {
+  Box,
+  Typography,
+  Paper,
+  TextField,
+  Button,
+  Snackbar,
+  Alert,
+  InputAdornment,
+} from '@mui/material';
+import { PageContainer } from '@/components/layout/page-container';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { User, Mail as MailIcon, MessageSquare } from 'lucide-react';
+
+// フォームの入力値を検証するためのスキーマを定義
+const contactSchema = z.object({
+  name: z.string().min(1, '名前は必須です'),
+  email: z.string().email('正しいメールアドレスを入力してください'),
+  message: z.string().min(1, 'お問い合わせ内容を入力してください'),
+});
+
+// スキーマから型を生成してフォームデータに利用
+type ContactForm = z.infer<typeof contactSchema>;
+
+// お問い合わせページ: ユーザーからの問い合わせを受け付けるフォームを提供
+export function ContactPage() {
+  // 送信完了メッセージの表示状態を管理
+  const [open, setOpen] = useState(false);
+
+  // React Hook Formを使用してフォーム状態とバリデーションを管理
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<ContactForm>({
+    resolver: zodResolver(contactSchema),
+  });
+
+  // フォーム送信時の処理
+  const onSubmit = (data: ContactForm) => {
+    console.log('contact submit', data);
+    setOpen(true);
+    reset();
+  };
+
+  return (
+    <PageContainer>
+      {/* ページヘッダー */}
+      <Box>
+        <Typography variant="h4" component="h1" fontWeight={600} gutterBottom>
+          お問い合わせ
+        </Typography>
+        <Typography variant="body1" color="text.secondary">
+          ご質問やご相談がありましたら、以下のフォームからお気軽にご連絡ください。
+        </Typography>
+      </Box>
+
+      {/* お問い合わせフォーム */}
+      <Paper sx={{ p: 4 }}>
+        <Box
+          component="form"
+          onSubmit={handleSubmit(onSubmit)}
+          sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}
+        >
+          <TextField
+            label="お名前"
+            fullWidth
+            {...register('name')}
+            error={!!errors.name}
+            helperText={errors.name?.message}
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">
+                  <User size={18} />
+                </InputAdornment>
+              ),
+            }}
+          />
+          <TextField
+            label="メールアドレス"
+            type="email"
+            fullWidth
+            {...register('email')}
+            error={!!errors.email}
+            helperText={errors.email?.message}
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">
+                  <MailIcon size={18} />
+                </InputAdornment>
+              ),
+            }}
+          />
+          <TextField
+            label="お問い合わせ内容"
+            multiline
+            rows={4}
+            fullWidth
+            {...register('message')}
+            error={!!errors.message}
+            helperText={errors.message?.message}
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start" sx={{ alignSelf: 'flex-start', mt: 1 }}>
+                  <MessageSquare size={18} />
+                </InputAdornment>
+              ),
+            }}
+          />
+          <Button type="submit" variant="contained" sx={{ alignSelf: 'flex-start' }}>
+            送信する
+          </Button>
+        </Box>
+      </Paper>
+
+      {/* 送信完了メッセージ */}
+      <Snackbar open={open} autoHideDuration={4000} onClose={() => setOpen(false)}>
+        <Alert onClose={() => setOpen(false)} severity="success" variant="filled">
+          メッセージを送信しました。
+        </Alert>
+      </Snackbar>
+    </PageContainer>
+  );
+}

--- a/src/pages/notifications.tsx
+++ b/src/pages/notifications.tsx
@@ -10,8 +10,8 @@ import {
   ListItemText,
   Paper,
   Tooltip,
-  Typography
-} from '@mui/material'
+  Typography,
+} from '@mui/material';
 import {
   AccessTime,
   Cancel,
@@ -22,48 +22,47 @@ import {
   Group,
   Payment,
   ReceiptLong,
-  Star
-} from '@mui/icons-material'
-import { mockNotifications } from '@/data/notifications'
-import { PageContainer } from '@/components/layout/page-container'
-import { mockNotifications } from '@/data/notifications'
-import type { Notification } from '@/schemas'
-
-// Single notification item type derived from mock data
-type Notification = (typeof mockNotifications)[number]
+  Star,
+} from '@mui/icons-material';
+import { mockNotifications } from '@/data/notifications';
+import { PageContainer } from '@/components/layout/page-container';
+import type { Notification } from '@/schemas';
 
 /**
  * オーナー向け通知一覧ページ
  * MUIコンポーネントを用いてシンプルで直感的なUIを構築します。
  */
 export function NotificationsPage() {
+  // モックデータを元に通知一覧と未読件数を計算
+  const notifications = mockNotifications;
+  const unreadCount = notifications.filter((n) => !n.readAt).length;
   /**
    * 通知タイプごとのアイコンを返すヘルパー
    */
   const getNotificationIcon = (type: Notification['type']) => {
     switch (type) {
       case 'job_application':
-        return <Group fontSize="small" />
+        return <Group fontSize="small" />;
       case 'job_submitted':
-        return <CheckCircle fontSize="small" />
+        return <CheckCircle fontSize="small" />;
       case 'job_started':
-        return <AccessTime fontSize="small" />
+        return <AccessTime fontSize="small" />;
       case 'invoice_issued':
-        return <ReceiptLong fontSize="small" />
+        return <ReceiptLong fontSize="small" />;
       case 'job_rework_requested':
-        return <Cancel fontSize="small" />
+        return <Cancel fontSize="small" />;
       case 'payment_received':
-        return <Payment fontSize="small" />
+        return <Payment fontSize="small" />;
       case 'job_cancelled':
-        return <Cancel fontSize="small" />
+        return <Cancel fontSize="small" />;
       case 'worker_rating':
-        return <Star fontSize="small" />
+        return <Star fontSize="small" />;
       case 'offer_accepted':
-        return <CheckCircle fontSize="small" />
+        return <CheckCircle fontSize="small" />;
       default:
-        return <AccessTime fontSize="small" />
+        return <AccessTime fontSize="small" />;
     }
-  }
+  };
 
   /**
    * 通知タイプに応じたアバター背景色を返す
@@ -71,51 +70,40 @@ export function NotificationsPage() {
   const getNotificationColor = (type: Notification['type']) => {
     switch (type) {
       case 'job_application':
-        return 'success.main'
+        return 'success.main';
       case 'job_submitted':
-        return 'info.main'
+        return 'info.main';
       case 'job_started':
-        return 'warning.main'
+        return 'warning.main';
       case 'invoice_issued':
-        return 'secondary.main'
+        return 'secondary.main';
       case 'job_rework_requested':
-        return 'error.main'
+        return 'error.main';
       case 'payment_received':
-        return 'success.dark'
+        return 'success.dark';
       case 'job_cancelled':
-        return 'error.main'
+        return 'error.main';
       case 'worker_rating':
-        return 'warning.dark'
+        return 'warning.dark';
       case 'offer_accepted':
-        return 'success.main'
+        return 'success.main';
       default:
-        return 'grey.500'
+        return 'grey.500';
     }
-  }
+  };
 
   /**
    * 相対時間表示を生成（例: "3分前"）
    */
   const formatTimeAgo = (dateString: string) => {
-    const date = new Date(dateString)
-    const now = new Date()
-    const diffInMinutes = Math.floor((now.getTime() - date.getTime()) / (1000 * 60))
+    const date = new Date(dateString);
+    const now = new Date();
+    const diffInMinutes = Math.floor((now.getTime() - date.getTime()) / (1000 * 60));
 
-    if (diffInMinutes < 60) return `${diffInMinutes}分前`
-    if (diffInMinutes < 1440) return `${Math.floor(diffInMinutes / 60)}時間前`
-    return `${Math.floor(diffInMinutes / 1440)}日前`
-  }
-
-  // サマリー表示用の件数集計
-  const summary = useMemo(
-    () => ({
-      unread: unreadCount,
-      application: notifications.filter(n => n.type === 'job_application').length,
-      submitted: notifications.filter(n => n.type === 'job_submitted').length,
-      billing: notifications.filter(n => ['invoice_issued', 'payment_received'].includes(n.type)).length,
-    }),
-    [notifications, unreadCount]
-  )
+    if (diffInMinutes < 60) return `${diffInMinutes}分前`;
+    if (diffInMinutes < 1440) return `${Math.floor(diffInMinutes / 60)}時間前`;
+    return `${Math.floor(diffInMinutes / 1440)}日前`;
+  };
 
   return (
     <PageContainer>
@@ -144,7 +132,9 @@ export function NotificationsPage() {
       {/* ===== Summary cards ===== */}
       <Grid container spacing={2}>
         <Grid item xs={12} sm={3}>
-          <Paper sx={{ p: 2, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <Paper
+            sx={{ p: 2, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}
+          >
             <Box>
               <Typography variant="subtitle2" color="primary">
                 未読
@@ -155,39 +145,49 @@ export function NotificationsPage() {
           </Paper>
         </Grid>
         <Grid item xs={12} sm={3}>
-          <Paper sx={{ p: 2, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <Paper
+            sx={{ p: 2, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}
+          >
             <Box>
               <Typography variant="subtitle2" color="success">
                 応募通知
               </Typography>
               <Typography variant="h5">
-                {mockNotifications.filter(n => n.type === 'job_application').length}
+                {mockNotifications.filter((n) => n.type === 'job_application').length}
               </Typography>
             </Box>
             <Group color="success" />
           </Paper>
         </Grid>
         <Grid item xs={12} sm={3}>
-          <Paper sx={{ p: 2, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <Paper
+            sx={{ p: 2, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}
+          >
             <Box>
               <Typography variant="subtitle2" color="info">
                 作業完了
               </Typography>
               <Typography variant="h5">
-                {mockNotifications.filter(n => n.type === 'job_submitted').length}
+                {mockNotifications.filter((n) => n.type === 'job_submitted').length}
               </Typography>
             </Box>
             <CheckCircle color="info" />
           </Paper>
         </Grid>
         <Grid item xs={12} sm={3}>
-          <Paper sx={{ p: 2, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+          <Paper
+            sx={{ p: 2, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}
+          >
             <Box>
               <Typography variant="subtitle2" color="secondary">
                 請求・支払
               </Typography>
               <Typography variant="h5">
-                {mockNotifications.filter(n => ['invoice_issued', 'payment_received'].includes(n.type)).length}
+                {
+                  mockNotifications.filter((n) =>
+                    ['invoice_issued', 'payment_received'].includes(n.type),
+                  ).length
+                }
               </Typography>
             </Box>
             <Payment color="secondary" />
@@ -197,12 +197,12 @@ export function NotificationsPage() {
 
       {/* ===== Notification list ===== */}
       <List sx={{ width: '100%' }}>
-        {mockNotifications.map(notification => (
+        {mockNotifications.map((notification) => (
           <Paper
             key={notification.id}
             sx={{
               mb: 2,
-              bgcolor: notification.readAt ? 'background.paper' : 'action.hover'
+              bgcolor: notification.readAt ? 'background.paper' : 'action.hover',
             }}
           >
             <ListItem
@@ -276,12 +276,14 @@ export function NotificationsPage() {
                     )}
                     {notification.type === 'payment_received' && (
                       <Typography variant="body2" color="text.secondary">
-                        請求書の支払い（¥{notification.payload.amount?.toLocaleString()}）を受領しました。
+                        請求書の支払い（¥{notification.payload.amount?.toLocaleString()}
+                        ）を受領しました。
                       </Typography>
                     )}
                     {notification.type === 'worker_rating' && (
                       <Typography variant="body2" color="text.secondary">
-                        <strong>{notification.payload.workerName}</strong>さんの作業評価をお願いします。
+                        <strong>{notification.payload.workerName}</strong>
+                        さんの作業評価をお願いします。
                       </Typography>
                     )}
                     {notification.type === 'offer_accepted' && (
@@ -312,6 +314,5 @@ export function NotificationsPage() {
         <Typography color="text.secondary">すべての通知を表示しました</Typography>
       </Box>
     </PageContainer>
-  )
+  );
 }
-


### PR DESCRIPTION
## Summary
- add contact page with validated form and success feedback
- link contact page in sidebar and routing
- clean up notifications page to satisfy lint

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b23ab98bd88324b05fb2c00b90376c